### PR TITLE
Removed /public from .gitignore since it includes required files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 # production
 /build
-/public
 
 # misc
 .DS_Store


### PR DESCRIPTION
The public directory contains the index.html file that is required by the create-react-app config. This PR does not include those files, since I dont have them