### PR TITLE
menu: show current values

### DIFF
--- a/src/components/collage.css
+++ b/src/components/collage.css
@@ -110,3 +110,12 @@ table {
   width: 100px;
   height: 150px;
 }
+
+.count {
+  display: flex;
+  justify-content: space-between;
+}
+
+.count-container {
+  max-width: 105px;
+}

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -47,7 +47,7 @@ export const ConfigMenu: React.FC<Props> = ({ tableRef: chartRef }) => {
           {/* </Form.Field> */}
         </Form>
       </Menu.Item>
-      <Menu.Item style={{ maxWidth: 105 }}>
+      <Menu.Item className="count-container">
         <p className="count">
           <b>Rows</b>
           <Label horizontal>{rows}</Label>
@@ -56,7 +56,7 @@ export const ConfigMenu: React.FC<Props> = ({ tableRef: chartRef }) => {
         <Button content="-" onClick={() => dispatchConfig({ type: "rows", value: rows - 1 })} />
         <Button content="+" onClick={() => dispatchConfig({ type: "rows", value: rows + 1 })} />
       </Menu.Item>
-      <Menu.Item style={{ maxWidth: 105 }}>
+      <Menu.Item className="count-container">
         <p className="count">
           <b>Columns</b>
           <Label horizontal>{cols}</Label>
@@ -65,7 +65,7 @@ export const ConfigMenu: React.FC<Props> = ({ tableRef: chartRef }) => {
         <Button content="+" onClick={() => dispatchConfig({ type: "cols", value: cols + 1 })} />
       </Menu.Item>
 
-      <Menu.Item style={{ maxWidth: 105 }}>
+      <Menu.Item className="count-container">
         <p className="count">
           <b>Padding</b>
           <Label horizontal>{pad}</Label>

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React, { useContext } from "react";
-import { Button, Menu, Form, Radio } from "semantic-ui-react";
+import { Button, Menu, Form, Radio, Label } from "semantic-ui-react";
 import { useScreenshot } from "use-screenshot-hook";
 
 import { ChartType, ConfigContext } from "./config";
@@ -47,24 +47,28 @@ export const ConfigMenu: React.FC<Props> = ({ tableRef: chartRef }) => {
           {/* </Form.Field> */}
         </Form>
       </Menu.Item>
-      <Menu.Item>
-        <p>
+      <Menu.Item style={{ maxWidth: 105 }}>
+        <p className="count">
           <b>Rows</b>
+          <Label horizontal>{rows}</Label>
         </p>
+
         <Button content="-" onClick={() => dispatchConfig({ type: "rows", value: rows - 1 })} />
         <Button content="+" onClick={() => dispatchConfig({ type: "rows", value: rows + 1 })} />
       </Menu.Item>
-      <Menu.Item>
-        <p>
+      <Menu.Item style={{ maxWidth: 105 }}>
+        <p className="count">
           <b>Columns</b>
+          <Label horizontal>{cols}</Label>
         </p>
         <Button content="-" onClick={() => dispatchConfig({ type: "cols", value: cols - 1 })} />
         <Button content="+" onClick={() => dispatchConfig({ type: "cols", value: cols + 1 })} />
       </Menu.Item>
 
-      <Menu.Item>
-        <p>
-          <b>Padding </b>
+      <Menu.Item style={{ maxWidth: 105 }}>
+        <p className="count">
+          <b>Padding</b>
+          <Label horizontal>{pad}</Label>
         </p>
         <Button content="-" onClick={() => dispatchConfig({ type: "pad", value: pad - 1 })} />
         <Button content="+" onClick={() => dispatchConfig({ type: "pad", value: pad + 1 })} />

--- a/src/index.css
+++ b/src/index.css
@@ -11,8 +11,3 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
-
-.count {
-  display: flex;
-  justify-content: space-between;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.count {
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
Please let me know if anything is not aligned with the project's code style.

## Styling
I was using Semantic UI's labels, but I had to add some extra styling.

- I've added `style={{maxWidth: 105}}` to the first three Menu.Item components.
- I've added the following class in index.css:
```
.count {
  display: flex;
  justify-content: space-between;
}
```

Those changes allowed me to distribute the titles and the values symmetrically across the Menu.Item component.

## Preview
<img width="226" alt="Screen Shot 2020-10-07 at 10 21 45" src="https://user-images.githubusercontent.com/46726774/95299782-eb39b680-0886-11eb-938d-4fd0ed453229.png">
